### PR TITLE
feat: login api integration

### DIFF
--- a/client/src/context/AuthContext.tsx
+++ b/client/src/context/AuthContext.tsx
@@ -1,11 +1,10 @@
-import { useMutation } from "@tanstack/react-query";
-import axios from "axios";
-import { createContext } from "react";
-import { useContext } from "react";
-import toast from "react-hot-toast";
-import { useNavigate } from "react-router-dom";
+import { useMutation } from '@tanstack/react-query';
+import axios from 'axios';
+import { createContext, useMemo, useContext } from 'react';
+import toast from 'react-hot-toast';
+import { useNavigate } from 'react-router-dom';
 
-import { AuthContext, AuthProviderProps, User } from "./types";
+import { AuthContext, AuthProviderProps, User } from './types';
 
 const Context = createContext<AuthContext | null>(null);
 const SignupMethod = (navigation: (a: string) => void) =>
@@ -15,23 +14,40 @@ const SignupMethod = (navigation: (a: string) => void) =>
     },
     onSuccess: () => {
       toast.success(
-        "User has been created successfully. Please login to continue...!",
+        'User has been created successfully. Please login to continue...!',
         {
           duration: 3000,
         }
       );
       setTimeout(() => {
-        navigation("/login");
+        navigation('/login');
       }, 2000);
+    },
+  });
+
+const LoginMethod = (navigation: (a: string) => void) =>
+  useMutation({
+    mutationFn: (userName: string) => {
+      return axios.post(`${import.meta.env.VITE_SERVER_URL}/login`, userName);
+    },
+    onSuccess: () => {
+      toast.success('Login successful...!', {
+        duration: 2000,
+      });
+      setTimeout(() => {
+        navigation('/');
+      }, 1000);
     },
   });
 
 export const useAuth = () => useContext(Context) as AuthContext;
 
-export const AuthProvider = ({ children }: AuthProviderProps) => {
+export function AuthProvider({ children }: AuthProviderProps) {
   const navigate = useNavigate();
   const signup = SignupMethod(navigate);
-  const isSuccess = signup.isSuccess;
+  const login = LoginMethod(navigate);
+  const { isSuccess } = signup;
+  const isValidUser = login.isSuccess;
 
   // if(isSuccess){
   //
@@ -40,8 +56,13 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   // console.log(signup)
 
   return (
-    <Context.Provider value={{ signup, isSuccess }}>
+    <Context.Provider
+      value={useMemo(
+        () => ({ signup, isSuccess, isValidUser, login }),
+        [signup, isSuccess, isValidUser, login]
+      )}
+    >
       {children}
     </Context.Provider>
   );
-};
+}

--- a/client/src/context/AuthContext.tsx
+++ b/client/src/context/AuthContext.tsx
@@ -49,12 +49,6 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const { isSuccess } = signup;
   const isValidUser = login.isSuccess;
 
-  // if(isSuccess){
-  //
-  // }
-
-  // console.log(signup)
-
   return (
     <Context.Provider
       value={useMemo(

--- a/client/src/context/AuthContext.tsx
+++ b/client/src/context/AuthContext.tsx
@@ -27,8 +27,10 @@ const SignupMethod = (navigation: (a: string) => void) =>
 
 const LoginMethod = (navigation: (a: string) => void) =>
   useMutation({
-    mutationFn: (userName: string) => {
-      return axios.post(`${import.meta.env.VITE_SERVER_URL}/login`, userName);
+    mutationFn: (loginUser: string) => {
+      return axios.post(`${import.meta.env.VITE_SERVER_URL}/login`, {
+        id: loginUser,
+      });
     },
     onSuccess: () => {
       toast.success('Login successful...!', {

--- a/client/src/context/Provider.tsx
+++ b/client/src/context/Provider.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from 'react-router-dom';
+
+import { AuthProvider } from './AuthContext';
+
+export default function ContextProvider() {
+  return (
+    <AuthProvider>
+      <Outlet />
+    </AuthProvider>
+  );
+}

--- a/client/src/context/types.ts
+++ b/client/src/context/types.ts
@@ -1,10 +1,12 @@
-import { UseMutationResult } from "@tanstack/react-query";
-import { AxiosResponse } from "axios";
-import { ReactNode } from "react";
+import { UseMutationResult } from '@tanstack/react-query';
+import { AxiosResponse } from 'axios';
+import { ReactNode } from 'react';
 
 export type AuthContext = {
   signup: UseMutationResult<AxiosResponse, unknown, User>;
   isSuccess: boolean;
+  isValidUser: boolean;
+  login: UseMutationResult<AxiosResponse, unknown, string>;
 };
 
 export type AuthProviderProps = {

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
 
 import './index.css';
-import { router } from './router';
+import router from './router';
 
 const queryClient = new QueryClient(); // creates a new queryClient and allows react query to work
 

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -13,6 +13,5 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />
     </QueryClientProvider>
-    P
   </React.StrictMode>
 );

--- a/client/src/pages/Dashboard/index.tsx
+++ b/client/src/pages/Dashboard/index.tsx
@@ -1,0 +1,5 @@
+const Dashboard = () => {
+  return <div>Dashboard</div>;
+};
+
+export default Dashboard;

--- a/client/src/pages/Login/index.tsx
+++ b/client/src/pages/Login/index.tsx
@@ -44,8 +44,8 @@ function Login() {
           {/* eslint-disable jsx-a11y/label-has-associated-control */}
           <label htmlFor="username" className="block text-gray-700 font-bold">
             Username
-            <Input type="text" id="username" required ref={userNameRef} />
           </label>
+          <Input type="text" id="username" required ref={userNameRef} />
 
           <ActionButton loading={loading} label="Login" type="submit" />
         </form>

--- a/client/src/pages/Login/index.tsx
+++ b/client/src/pages/Login/index.tsx
@@ -1,23 +1,29 @@
-import { FormEvent, useRef, useState } from "react";
-import { Link } from "react-router-dom";
-import toast, { Toaster } from "react-hot-toast";
+// eslint-disable-file jsx-a11y/label-has-associated-control
+import { FormEvent, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import toast, { Toaster } from 'react-hot-toast';
 
-import { Card } from "components/Card";
-import ActionButton from "components/ActionButton";
-import Input from "components/Input";
+import { Card } from 'components/Card';
+import ActionButton from 'components/ActionButton';
+import Input from 'components/Input';
+import { useAuth } from 'context/AuthContext';
 
-const Login = () => {
+function Login() {
   const userNameRef = useRef<HTMLInputElement>(null);
   const [loading, setLoading] = useState(false); // to be removed once login BE integration is done
+  const { login } = useAuth();
 
   function onSubmit(e: FormEvent) {
     e.preventDefault();
+    if (login.isLoading) return;
+
     const userName = userNameRef.current?.value;
-    if (!userName || userName === " ") {
-      toast.error("Please input a correct login username!");
+    if (!userName || userName === ' ') {
+      toast.error('Please input a correct login username!');
       return;
     }
     setLoading(true);
+    login.mutate(userName);
 
     // add login logic here
     setTimeout(() => setLoading(false), 4000); // to be removed once login integration is done
@@ -35,17 +41,18 @@ const Login = () => {
           className="grid gris-cols-[auto,1fr] gap-x-3 gap-y-5 items-center justify-items-start"
           onSubmit={onSubmit}
         >
+          {/* eslint-disable jsx-a11y/label-has-associated-control */}
           <label htmlFor="username" className="block text-gray-700 font-bold">
             Username
+            <Input type="text" id="username" required ref={userNameRef} />
           </label>
-          <Input type="text" id="username" required ref={userNameRef} />
 
           <ActionButton loading={loading} label="Login" type="submit" />
         </form>
       </Card.Body>
       <Card.Footer>
         <p className="text-black">
-          Not an existing user?{" "}
+          Not an existing user?{' '}
           <Link to="/signup">
             <em className="text-blue-600">Signup</em>
           </Link>
@@ -53,6 +60,6 @@ const Login = () => {
       </Card.Footer>
     </>
   );
-};
+}
 
 export default Login;

--- a/client/src/pages/Signup/index.tsx
+++ b/client/src/pages/Signup/index.tsx
@@ -1,13 +1,13 @@
-import React, { FormEvent, useRef } from "react";
-import toast, { Toaster } from "react-hot-toast";
-import { Link } from "react-router-dom";
+import React, { FormEvent, useRef } from 'react';
+import toast, { Toaster } from 'react-hot-toast';
+import { Link } from 'react-router-dom';
 
-import { Card } from "components/Card";
-import Input from "components/Input";
-import ActionButton from "components/ActionButton";
-import { useAuth } from "context/AuthContext";
+import { Card } from 'components/Card';
+import Input from 'components/Input';
+import ActionButton from 'components/ActionButton';
+import { useAuth } from 'context/AuthContext';
 
-const Signup = () => {
+function Signup() {
   const { signup } = useAuth();
 
   const usernameRef = useRef<HTMLInputElement>(null);
@@ -25,8 +25,8 @@ const Signup = () => {
     const name = nameRef.current?.value;
     const imageUrl = imageRef.current?.value;
 
-    if (!userName || userName === " " || !name || name === " ") {
-      toast.error("Please input a correct signup credentials!");
+    if (!userName || userName === ' ' || !name || name === ' ') {
+      toast.error('Please input a correct signup credentials!');
       return;
     }
 
@@ -34,7 +34,7 @@ const Signup = () => {
   };
 
   return (
-    <React.Fragment>
+    <>
       <Toaster />
       <Card.Header>
         <h1 className="text-3xl font-bold mb-2 text-center">Sign Up</h1>
@@ -44,6 +44,7 @@ const Signup = () => {
           className="grid gris-cols-[auto,1fr] gap-x-3 gap-y-5 items-center justify-items-start"
           onSubmit={submitHandler}
         >
+          {/* eslint-disable jsx-a11y/label-has-associated-control */}
           <label htmlFor="username" className="block text-gray-700 font-bold">
             Username
           </label>
@@ -65,14 +66,14 @@ const Signup = () => {
       </Card.Body>
       <Card.Footer>
         <p className="text-black">
-          Already an existing user?{" "}
+          Already an existing user?{' '}
           <Link to="/login">
             <em className="text-blue-600">Login</em>
           </Link>
         </p>
       </Card.Footer>
-    </React.Fragment>
+    </>
   );
-};
+}
 
 export default Signup;

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -1,9 +1,10 @@
-import { createBrowserRouter, Outlet } from "react-router-dom";
+import { createBrowserRouter, Outlet } from 'react-router-dom';
 
-import { AuthProvider } from "./context/AuthContext";
-import Authlayout from "./pages/layouts/Authlayout";
-import Login from "./pages/Login";
-import Signup from "./pages/Signup";
+import { AuthProvider } from './context/AuthContext';
+import Dashboard from './pages/Dashboard';
+import Authlayout from './pages/layouts/Authlayout';
+import Login from './pages/Login';
+import Signup from './pages/Signup';
 
 export const router = createBrowserRouter([
   {
@@ -13,8 +14,9 @@ export const router = createBrowserRouter([
         element: <Authlayout />,
 
         children: [
-          { path: "/login", element: <Login /> },
-          { path: "/signup", element: <Signup /> },
+          { path: '/login', element: <Login /> },
+          { path: '/signup', element: <Signup /> },
+          { path: '/', element: <Dashboard /> },
         ],
       },
     ],

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -1,12 +1,12 @@
-import { createBrowserRouter, Outlet } from 'react-router-dom';
+import { createBrowserRouter } from 'react-router-dom';
 
-import { AuthProvider } from './context/AuthContext';
+import ContextProvider from './context/Provider';
 import Dashboard from './pages/Dashboard';
 import Authlayout from './pages/layouts/Authlayout';
 import Login from './pages/Login';
 import Signup from './pages/Signup';
 
-export const router = createBrowserRouter([
+const router = createBrowserRouter([
   {
     element: <ContextProvider />,
     children: [
@@ -23,10 +23,4 @@ export const router = createBrowserRouter([
   },
 ]);
 
-function ContextProvider() {
-  return (
-    <AuthProvider>
-      <Outlet />
-    </AuthProvider>
-  );
-}
+export default router;


### PR DESCRIPTION
### Task Link

---
- https://www.notion.so/FE-Integrate-Login-API-to-UI-04fdbdecb1bf4be9a1b9cc9466c0deb7?pvs=4
---

### Description

---
- integrate the Backend `post /login` route to the Frontend Login UI 

#### Additional Changes
- some refactors around Signup, router and Context Provider
-  remove the unwanted `P` character that was coming in each route which was unintentionally added [here](https://github.com/javascript-shinobis/messaging-app/blame/main/client/src/main.tsx#L16)
- add a dashboard route and its corresponding container to prevent the landing page ErrorBoundary error
---

### Screenshot / Gif (If Any)

---
- ![login-api](https://user-images.githubusercontent.com/55781078/227252838-374d2029-c70d-4dba-a927-9506c837aba0.gif)

---

### TODO Checklist

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added]
- [ ] Relevant documentation is changed or added (and PR referenced)
