### PR TITLE
feat: create client chat page

### DIFF
--- a/client/src/components/ActionButton/types.ts
+++ b/client/src/components/ActionButton/types.ts
@@ -1,11 +1,11 @@
-import React, { MouseEvent } from "react";
+import { MouseEvent } from 'react';
 
 export interface ActionButtonProps {
   bgColor?: string;
   label: string;
   labelColor?: string;
   loading?: boolean;
-  type: "submit" | "reset" | "button";
+  type: 'submit' | 'reset' | 'button';
   disabled?: boolean;
   onClick?: (event: MouseEvent) => void;
 }

--- a/client/src/components/Card/index.tsx
+++ b/client/src/components/Card/index.tsx
@@ -1,4 +1,4 @@
-import { CardProps } from "./types";
+import { CardProps } from './types';
 
 /**
  * @date 2023-02-21
@@ -7,26 +7,33 @@ import { CardProps } from "./types";
  * @param {ReactDOM} {children}
  * @returns {any}
  */
-export const Card = ({ children }: CardProps) => {
+export function Card({ children }: CardProps) {
   return (
-    <div className="flex justify-center items-center min-h-screen bg-gray-100 border-slate-300">
+    <div className="flex justify-center items-center min-h-screen bg-gray-100 w-full border-slate-300">
       <div className="max-w-md w-full">{children}</div>
+    </div>
+  );
+}
+
+Card.Header = function CardHeader({ children }: CardProps) {
+  return (
+    <div className="text-lg justify-center flex font-semibold p-3 text-cyan-500">
+      {children}
     </div>
   );
 };
 
-Card.Header = ({ children }: CardProps) => (
-  <div className="text-lg justify-center flex font-semibold p-3">
-    {children}
-  </div>
-);
-
-Card.Body = ({ children }: CardProps) => (
-  <div className="shadow bg-white p-6 rounded-lg w-96 mx-auto">{children}</div>
-);
-
-Card.Footer = ({ children }: CardProps) => (
-  <div className="mt-2 p-1  bg-white justify-center  rounded-lg flex gap-1 w-96 mx-auto">
-    {children}
-  </div>
-);
+Card.Body = function CardBody({ children }: CardProps) {
+  return (
+    <div className="shadow bg-white p-6 rounded-lg w-96 mx-auto">
+      {children}
+    </div>
+  );
+};
+Card.Footer = function CardFooter({ children }: CardProps) {
+  return (
+    <div className="mt-2 p-1  bg-white justify-center  rounded-lg flex gap-1 w-96 mx-auto">
+      {children}
+    </div>
+  );
+};

--- a/client/src/components/Card/index.tsx
+++ b/client/src/components/Card/index.tsx
@@ -31,7 +31,7 @@ Card.Body = function CardBody({ children }: CardProps) {
 };
 Card.Footer = function CardFooter({ children }: CardProps) {
   return (
-    <div className="mt-2 p-1  bg-white justify-center  rounded-lg flex gap-1 w-96 mx-auto">
+    <div className="mt-2 p-1  bg-white justify-center  rounded-lg flex gap-1 w-96 mx-auto shadow">
       {children}
     </div>
   );

--- a/client/src/components/Card/index.tsx
+++ b/client/src/components/Card/index.tsx
@@ -5,7 +5,6 @@ import { CardProps } from './types';
  * @description A wrapper card component for our application
  * Divides components into three section
  * @param {ReactDOM} {children}
- * @returns {any}
  */
 export function Card({ children }: CardProps) {
   return (

--- a/client/src/context/AuthContext.tsx
+++ b/client/src/context/AuthContext.tsx
@@ -74,6 +74,8 @@ const LoginMethod = ({ navigation, setToken, setUser }: LoginMethodType) =>
   });
 
 export const useAuth = () => useContext(Context) as AuthContext;
+export const usePostLoginAuth = () =>
+  useContext(Context) as AuthContext & Required<Pick<AuthContext, 'user'>>;
 
 export function AuthProvider({ children }: AuthProviderProps) {
   const [user, setUser] = useState<User>();

--- a/client/src/context/AuthContext.tsx
+++ b/client/src/context/AuthContext.tsx
@@ -14,12 +14,14 @@ import {
   LoginCredentials,
   LoginResponseType,
   LoginMethodType,
+  SignupUserType,
 } from './types';
 
 const Context = createContext<AuthContext | null>(null);
+
 const SignupMethod = (navigation: (a: string) => void) =>
   useMutation({
-    mutationFn: (user: User) => {
+    mutationFn: (user: SignupUserType) => {
       return axios.post(`${import.meta.env.VITE_SERVER_URL}/signup`, user);
     },
     onSuccess: () => {

--- a/client/src/context/types.ts
+++ b/client/src/context/types.ts
@@ -4,7 +4,7 @@ import { ReactNode, Dispatch, SetStateAction } from 'react';
 import { DefaultGenerics, OwnUserResponse, StreamChat } from 'stream-chat';
 
 export type AuthContext = {
-  signup: UseMutationResult<AxiosResponse, unknown, User>;
+  signup: UseMutationResult<AxiosResponse, unknown, SignupUserType>;
   isSuccess: boolean;
   isValidUser: boolean;
   login: UseMutationResult<LoginResponseType, unknown, LoginCredentials>;

--- a/client/src/context/types.ts
+++ b/client/src/context/types.ts
@@ -34,3 +34,10 @@ export type LoginMethodType = {
   setToken: Dispatch<SetStateAction<string | undefined>>;
   setUser: Dispatch<SetStateAction<User | undefined>>;
 };
+
+export type SignupUserType = {
+  id: string;
+  name: string;
+  password: string;
+  imageUrl: string;
+};

--- a/client/src/pages/Dashboard/index.tsx
+++ b/client/src/pages/Dashboard/index.tsx
@@ -1,5 +1,32 @@
-const Dashboard = () => {
-  return <div>Dashboard</div>;
-};
+// eslint-disable-next-line import/no-extraneous-dependencies
+import isEmpty from 'lodash/isEmpty';
+import { useAuth } from 'context/AuthContext';
+import {
+  Channel,
+  ChannelHeader,
+  ChannelList,
+  Chat,
+  LoadingIndicator,
+  MessageInput,
+  MessageList,
+  Window,
+} from 'stream-chat-react';
+import 'stream-chat-react/dist/css/index.css';
 
-export default Dashboard;
+export default function Dashboard() {
+  const { user, streamChat } = useAuth();
+  if (!streamChat || isEmpty(streamChat)) return <LoadingIndicator />;
+
+  return (
+    <Chat client={streamChat}>
+      <ChannelList />
+      <Channel>
+        <Window>
+          <ChannelHeader />
+          <MessageList />
+          <MessageInput />
+        </Window>
+      </Channel>
+    </Chat>
+  );
+}

--- a/client/src/pages/Signup/index.tsx
+++ b/client/src/pages/Signup/index.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useRef } from 'react';
+import { FormEvent, useRef } from 'react';
 import toast, { Toaster } from 'react-hot-toast';
 import { Link } from 'react-router-dom';
 

--- a/client/src/pages/layouts/AuthLayout/index.tsx
+++ b/client/src/pages/layouts/AuthLayout/index.tsx
@@ -1,0 +1,5 @@
+import { Outlet } from 'react-router-dom';
+
+export default function Authlayout() {
+  return <Outlet />;
+}

--- a/client/src/pages/layouts/AuthLayout/index.tsx
+++ b/client/src/pages/layouts/AuthLayout/index.tsx
@@ -1,5 +1,10 @@
 import { Outlet } from 'react-router-dom';
+import { Card } from 'components/Card';
 
-export default function Authlayout() {
-  return <Outlet />;
+export default function AuthLayout() {
+  return (
+    <Card>
+      <Outlet />
+    </Card>
+  );
 }

--- a/client/src/pages/layouts/Authlayout.tsx
+++ b/client/src/pages/layouts/Authlayout.tsx
@@ -1,8 +1,0 @@
-import React from 'react';
-import { Outlet } from 'react-router-dom';
-
-function Authlayout() {
-  return <Outlet />;
-}
-
-export default Authlayout;

--- a/client/src/pages/layouts/RootLayout/index.tsx
+++ b/client/src/pages/layouts/RootLayout/index.tsx
@@ -1,5 +1,10 @@
 import { Outlet } from 'react-router-dom';
+import { Card } from 'components/Card';
 
 export default function Rootlayout() {
-  return <Outlet />;
+  return (
+    <Card>
+      <Outlet />
+    </Card>
+  );
 }

--- a/client/src/pages/layouts/RootLayout/index.tsx
+++ b/client/src/pages/layouts/RootLayout/index.tsx
@@ -1,7 +1,12 @@
-import { Outlet } from 'react-router-dom';
+import { Navigate, Outlet } from 'react-router-dom';
 import { Card } from 'components/Card';
+import { useAuth } from 'context/AuthContext';
 
 export default function Rootlayout() {
+  const { user } = useAuth();
+
+  if (!user) return <Navigate to="/login" />;
+
   return (
     <Card>
       <Outlet />

--- a/client/src/pages/layouts/RootLayout/index.tsx
+++ b/client/src/pages/layouts/RootLayout/index.tsx
@@ -1,0 +1,5 @@
+import { Outlet } from 'react-router-dom';
+
+export default function Rootlayout() {
+  return <Outlet />;
+}

--- a/client/src/pages/layouts/RootLayout/index.tsx
+++ b/client/src/pages/layouts/RootLayout/index.tsx
@@ -7,9 +7,5 @@ export default function Rootlayout() {
 
   if (!user) return <Navigate to="/login" />;
 
-  return (
-    <Card>
-      <Outlet />
-    </Card>
-  );
+  return <Outlet />;
 }

--- a/client/src/pages/layouts/RootLayout/index.tsx
+++ b/client/src/pages/layouts/RootLayout/index.tsx
@@ -1,5 +1,4 @@
 import { Navigate, Outlet } from 'react-router-dom';
-import { Card } from 'components/Card';
 import { useAuth } from 'context/AuthContext';
 
 export default function Rootlayout() {

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -21,7 +21,6 @@ const router = createBrowserRouter([
         children: [
           { path: '/login', element: <Login /> },
           { path: '/signup', element: <Signup /> },
-          { path: '/', element: <Dashboard /> },
         ],
       },
     ],

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -2,7 +2,8 @@ import { createBrowserRouter } from 'react-router-dom';
 
 import ContextProvider from './context/Provider';
 import Dashboard from './pages/Dashboard';
-import Authlayout from './pages/layouts/Authlayout';
+import Authlayout from './pages/layouts/AuthLayout';
+import Rootlayout from './pages/layouts/RootLayout';
 import Login from './pages/Login';
 import Signup from './pages/Signup';
 
@@ -11,8 +12,12 @@ const router = createBrowserRouter([
     element: <ContextProvider />,
     children: [
       {
+        path: '/',
+        element: <Rootlayout />,
+        children: [{ index: true, element: <Dashboard /> }],
+      },
+      {
         element: <Authlayout />,
-
         children: [
           { path: '/login', element: <Login /> },
           { path: '/signup', element: <Signup /> },


### PR DESCRIPTION
### Task Link

---
- https://www.notion.so/FE-Create-Client-Chat-Page-a6ad5abe3d4d413a9285d3aded1bea46?pvs=4
---

### Description

---

- Use reusable `stream-chat-react` components to design the Clients chat page in the landing page post login 
- Add RootLayout wrapper for post-login routes and make it protected 
##### Additonal Changes :-
- Some changes in `types` around AuthContext Provider according to requirements and errors from `typescript`
- Wrapped the `AuthLayout` Outlet with `Card` Component so its contents are rendered correctly at center 
- Some code refactors in Card Component
- `Card.Footer` has a new shadow 
---

### Screenshot / Gif (If Any)

---
![create-client](https://user-images.githubusercontent.com/55781078/227721480-d5bb324b-4910-4e92-963f-3bfa896ab0a7.gif)

---

### TODO Checklist

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added]
- [ ] Relevant documentation is changed or added (and PR referenced)
