### PR TITLE
feat: server logout route

### DIFF
--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -6,6 +6,9 @@ const streamChat = StreamChat.getInstance(
   process.env.STREAM_PRIVATE_API_KEY
 );
 
+// to keep track of the relation between user IDs and authentication tokens
+const TOKEN_USER_ID_MAP = new Map<string, string>();
+
 export async function userRoutes(app: FastifyInstance) {
   app.post<{
     Body: { id: string; name: string; image?: string; password: string };
@@ -65,6 +68,7 @@ export async function userRoutes(app: FastifyInstance) {
       if (user == null) return res.status(401).send();
 
       const token = streamChat.createToken(id);
+      TOKEN_USER_ID_MAP.set(token, user.id);
 
       return {
         token,
@@ -77,4 +81,19 @@ export async function userRoutes(app: FastifyInstance) {
       };
     }
   );
+
+  // eslint-disable-next-line consistent-return
+  app.post<{ Body: { token: string } }>('/logout', async (req, res) => {
+    const { token } = req.body;
+
+    if (!token || token === ' ') return res.status(400).send();
+
+    const id = TOKEN_USER_ID_MAP.get(token);
+
+    if (!id || id === '') return res.status(400).send();
+
+    await streamChat.revokeUserToken(id, new Date());
+
+    TOKEN_USER_ID_MAP.delete(token);
+  });
 }


### PR DESCRIPTION
### Task Link

https://www.notion.so/js-shinobis/BE-Server-Logout-Route-12c152f97b75450a91b75a674f7fd45f?pvs=4

### Description

* Added logout API route in server for logging out user.  
* Sample curl:-  
``` 
curl --location 'http://localhost:2999/logout' \
--header 'Content-Type: application/json' \
--data '{
    "id": "BabaYaga",
    "password": "Pencil"
}'
```

### Screenshot / Gif (If Any)

![logout](https://user-images.githubusercontent.com/108602441/227864208-4cf0965c-00a9-425f-9787-9cfa6a783dbc.gif)


### TODO Checklist

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added]
- [ ] Relevant documentation is changed or added (and PR referenced)
